### PR TITLE
fix: deprecated api

### DIFF
--- a/liquipediapy/counterstrike.py
+++ b/liquipediapy/counterstrike.py
@@ -143,7 +143,7 @@ class counterstrike():
 
 	def get_upcoming_and_ongoing_games(self):
 		games = []
-		soup,__ = self.liquipedia.parse('Liquipedia:Upcoming_and_ongoing_matches')
+		soup,__ = self.liquipedia.parse('Liquipedia:Matches')
 		matches = soup.find_all('table',class_='infobox_matches_content')
 		for match in matches:
 			game = {}


### PR DESCRIPTION
The orginal page is deprecated. [fyi](https://liquipedia.net/counterstrike/Liquipedia:Upcoming_and_ongoing_matches)