### PR TITLE
fix data format for tournament by type

### DIFF
--- a/liquipediapy/dota.py
+++ b/liquipediapy/dota.py
@@ -210,15 +210,19 @@ class dota():
 			tournament = {}
 
 			values = row.find('div',class_="Tournament").get_text().split('\n')
-			tournament['tier'] = re.sub('\W+',' ',values[0]).strip()
-			tournament['name'] = values[1]
+			if tournamentType is None:
+				tournament['tier'] = re.sub('\W+',' ',values[1]).strip()
+				tournament['name'] = row.find('div',class_="mobile-hide").get_text()
+			else:
+				tournament['tier'] = tournamentType
+				tournament['name'] = values[1].strip()
 
 			try:
 				tournament['icon'] = self.__image_base_url+row.find('div',class_="Tournament").find('img').get('src')
 			except AttributeError:
 				pass	
 
-			tournament['dates'] = row.find('div',class_="Date").get_text()
+			tournament['dates'] = row.find('div',class_="Date").get_text().strip()
 
 			try:
 				tournament['prize_pool'] = int(row.find('div',class_="Prize").get_text().rstrip().replace('$','').replace(',',''))
@@ -235,7 +239,7 @@ class dota():
 				pass	
 		
 			if len(row) < 15:
-				links_a = row.find('div',class_="SecondPlace").find_all('a')
+				links_a = row.find_all('a',class_="external text")
 				tournament['links'] = []
 				for link in links_a:
 					link_list = link.get('href').split('.')


### PR DESCRIPTION
I encountered an error while executing the get_tournaments function:
>>> dota_obj.get_tournaments ()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/liquipediapy/dota.py", line 238, in get_tournaments
    links_a = row.find ('div', class _ = "SecondPlace"). find_all ('a')
AttributeError: 'NoneType' object has no attribute 'find_all'

If you specify the argument Major or Premier, an error occurs:
>>> dota_obj.get_tournaments ('Major')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/liquipediapy/dota.py", line 238, in get_tournaments
    links_a = row.find ('div', class _ = "SecondPlace"). find_all ('a')
AttributeError: 'NoneType' object has no attribute 'find_all'

With argument Minor get_tournaments works correctly.

On the web page for parsing, I did not find some data. I guess that the layout has changed.
I have prepared a fix for these errors.