### PR TITLE
Fixed get_upcoming_and_ongoing_games endpoint 

### DIFF
--- a/liquipediapy/dota.py
+++ b/liquipediapy/dota.py
@@ -138,9 +138,9 @@ class dota():
 			game = {}
 			cells = match.find_all('td')
 			try:
-				game['team1'] = cells[0].find('span',class_='team-template-image').find('a').get('title')			
+				game['team1'] = cells[0].find('span',class_='team-template-image-icon').find('a').get('title')			
 				game['format'] = cells[1].find('abbr').get_text()
-				game['team2'] = cells[2].find('span',class_='team-template-image').find('a').get('title')
+				game['team2'] = cells[2].find('span',class_='team-template-image-icon').find('a').get('title')
 				game['start_time'] = cells[3].find('span',class_="timer-object").get_text()
 				game['tournament'] = cells[3].find('div').a['title']
 				game['tournament_short_name'] = cells[3].find('div').get_text().rstrip()


### PR DESCRIPTION
## Fixes
CSS class in get_upcoming_and_ongoing_games was incorrect/updated by liquipedia from `team-template-image` to `team-template-image-icon`. This broke the get_upcoming_and_ongoing_games endpoint.

## To test 
run a script to get upcoming and ongoing games from the get_upcoming_and_ongoing_games endpoint 