### PR TITLE
fix: Get team name when calling get_players

### DIFF
--- a/liquipediapy/counterstrike.py
+++ b/liquipediapy/counterstrike.py
@@ -28,7 +28,7 @@ class counterstrike():
 				player['name'] = name_list[1].replace(' ','')
 				player['country'] = row.find('a').get('title')
 				try:
-					team = row.find('span',class_='team-template-image').find('a').get('title')
+					team = row.find('span',class_='team-template-image-icon').find('a').get('title')
 				except AttributeError:
 					team = ''
 				player['team'] = team


### PR DESCRIPTION
A fix to get the team name.
The previous version was bringing "empty" to the team name.