### PR TITLE
fix index out of range for playerDetails query on CS

### DIFF
--- a/liquipediapy/counterstrike_modules/player.py
+++ b/liquipediapy/counterstrike_modules/player.py
@@ -58,7 +58,7 @@ class cs_player():
 				player['roles'] = player_roles
 			elif attribute == "Games":
 				games = []
-				game_values = info_boxes[i+1].find_all('i')	
+				game_values = info_boxes[i].find_all('i')	
 				for game in game_values:
 					games.append(game.get_text())
 				player['games'] = games	


### PR DESCRIPTION
dunno why it works, it just does. it wasn't random, I was doing some "debugging" by putting print statements everywhere. This probably definitely does not fix everything, but I'll try and work through it.