### PR TITLE
Fixed dota2 get_transfers player team and added Ref key for csgo and Dota2

### DIFF
--- a/liquipediapy/counterstrike.py
+++ b/liquipediapy/counterstrike.py
@@ -135,6 +135,11 @@ class counterstrike():
 						value = cells[i].find('a').get('title')	
 					except	AttributeError:
 						value = "None"
+				if key == "Ref":
+					try:
+						value = cells[i].find('a').get('href')	
+					except	AttributeError:
+						value = "None"
 				transfer[key] = value
 			transfer = {k: v for k, v in transfer.items() if len(k) > 0}	
 			transfers.append(transfer)	

--- a/liquipediapy/dota.py
+++ b/liquipediapy/dota.py
@@ -119,9 +119,14 @@ class dota():
 				value = cells[i].get_text()
 				if key == "Player":
 					value = [val for val in value.split(' ') if len(val) > 0]
-				if key == "Previous" or key == "Current":
+				if key == "Old" or key == "New":
 					try:
 						value = cells[i].find('a').get('title')	
+					except	AttributeError:
+						value = "None"
+				if key == "Ref":
+					try:
+						value = cells[i].find('a').get('href')	
 					except	AttributeError:
 						value = "None"
 				transfer[key] = value


### PR DESCRIPTION
fixed dota2 `get_transfers `def to take `Old` or `New` team key (instead of `Previous` and `Current`) of the player and added the `Ref` key to take the reference href link of the transfer, instead of the default text. 